### PR TITLE
Improve Layout of "Transactions" Links

### DIFF
--- a/css/mojito.css
+++ b/css/mojito.css
@@ -43,11 +43,15 @@ td.column-main > #column-main > .module {
     margin-bottom: 25px;
 }
 
+div.module-transactions > div.module-content {
+    font-size: 12px;
+}
+
 div.module-transactions > div.module-content > table {
     font-family: 'Helvetica Neue', HelveticaNeue, Helvetica, sans-serif;
-    font-size: 12px;
-     border: 1px solid #ddd;
-     width:100%;
+    border: 1px solid #ddd;
+    margin-bottom: 10px;
+    width:100%;
 }
 
 div.module-transactions tbody td {


### PR DESCRIPTION
Minor improvements to the "Transactions" table links:

- Reduces the font size of the links to 12px (which is the size of other footer-style links on the home page).
- Adds a 10px margin under the "Transactions" table (so the links are not right up against the table).